### PR TITLE
Add support for unsigned tile operations

### DIFF
--- a/dependencies/llvm/CMakeLists.txt
+++ b/dependencies/llvm/CMakeLists.txt
@@ -16,6 +16,9 @@ find_package(Clang REQUIRED CONFIG HINTS "${LLVM_DIR}/../clang")
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
 message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
 
+# LLVM_PACKAGE_VERSION does not propagate to higher scopes
+set(Halide_LLVM_VERSION ${LLVM_PACKAGE_VERSION} CACHE INTERNAL "Provided LLVM version")
+
 if (LLVM_PACKAGE_VERSION VERSION_LESS 10.0)
     message(FATAL_ERROR "LLVM version must be 10.0 or newer")
 endif ()

--- a/src/CodeGen_X86.cpp
+++ b/src/CodeGen_X86.cpp
@@ -206,7 +206,11 @@ const x86Intrinsic intrinsic_defs[] = {
     {"dpwssdsx4", Int(32, 4), "saturating_dot_product", {Int(32, 4), Int(16, 8), Int(16, 8)}, Target::AVX512_SapphireRapids},
 
     {"tileloadd64_i8", Int(8, 1024), "tile_load", {Int(16), Int(16), Handle(), Int(64), Int(64)}, Target::AVX512_SapphireRapids, x86Intrinsic::AccessesMemory},
+    {"tileloadd64_i8", UInt(8, 1024), "tile_load", {Int(16), Int(16), Handle(), Int(64), Int(64)}, Target::AVX512_SapphireRapids, x86Intrinsic::AccessesMemory},
     {"tdpbssd", Int(32, 256), "tile_matmul", {Int(16), Int(16), Int(16), Int(32, 256), Int(8, 1024), Int(8, 1024)},  Target::AVX512_SapphireRapids},
+    {"tdpbsud", Int(32, 256), "tile_matmul", {Int(16), Int(16), Int(16), Int(32, 256), Int(8, 1024), UInt(8, 1024)}, Target::AVX512_SapphireRapids},
+    {"tdpbusd", Int(32, 256), "tile_matmul", {Int(16), Int(16), Int(16), Int(32, 256), UInt(8, 1024), Int(8, 1024)}, Target::AVX512_SapphireRapids},
+    {"tdpbuud", Int(32, 256), "tile_matmul", {Int(16), Int(16), Int(16), Int(32, 256), UInt(8, 1024), UInt(8, 1024)}, Target::AVX512_SapphireRapids},
     {"tilezero_i32", Int(32, 256), "tile_zero", {Int(16), Int(16)},  Target::AVX512_SapphireRapids},
     // CodeGen_LLVM cannot cope with returning Type() ie void*, and return type needs to be vector to trigger call_overloaded_intrin
     {"tilestored64", Bool(2), "tile_store", {Int(16), Int(16), Handle(), Int(64), Int(64), Int(32, 256)}, Target::AVX512_SapphireRapids, x86Intrinsic::AccessesMemory},

--- a/src/ExtractTileOperations.cpp
+++ b/src/ExtractTileOperations.cpp
@@ -224,9 +224,9 @@ class ExtractTileOperations : public IRMutator {
     int found_tile_r = -1;
 
     Stmt visit(const Allocate *op) override {
-        if (op->memory_type == MemoryType::AMXTile &&
-            op->type.is_int() &&
-            op->type.bits() == 32) {
+        if (op->memory_type == MemoryType::AMXTile) {
+            user_assert(op->type.is_int() && op->type.bits() == 32) << "scheduled tile operations must yield 32-bit integers";
+
             // FIXME: Handle nested allocations better
             user_assert(!in_allocate) << "Found two possible tile allocations for AMX allocation";
             ScopedValue<string> old_amx_name(amx_name, op->name + ".amx");

--- a/src/LLVM_Runtime_Linker.cpp
+++ b/src/LLVM_Runtime_Linker.cpp
@@ -230,6 +230,7 @@ DECLARE_NO_INITMOD(windows_d3d12compute_arm)
 #endif  // WITH_D3D12
 
 #ifdef WITH_X86
+DECLARE_LL_INITMOD(x86_amx)
 DECLARE_LL_INITMOD(x86_avx512)
 DECLARE_LL_INITMOD(x86_avx2)
 DECLARE_LL_INITMOD(x86_avx)
@@ -237,6 +238,7 @@ DECLARE_LL_INITMOD(x86)
 DECLARE_LL_INITMOD(x86_sse41)
 DECLARE_CPP_INITMOD(x86_cpu_features)
 #else
+DECLARE_NO_INITMOD(x86_amx)
 DECLARE_NO_INITMOD(x86_avx512)
 DECLARE_NO_INITMOD(x86_avx2)
 DECLARE_NO_INITMOD(x86_avx)
@@ -1063,6 +1065,11 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
             if (t.has_feature(Target::AVX512)) {
                 modules.push_back(get_initmod_x86_avx512_ll(c));
             }
+#if LLVM_VERSION >= 120
+            if (t.has_feature(Target::AVX512_SapphireRapids)) {
+                modules.push_back(get_initmod_x86_amx_ll(c));
+            }
+#endif
             if (t.has_feature(Target::Profile)) {
                 user_assert(t.os != Target::WebAssemblyRuntime) << "The profiler cannot be used in a threadless environment.";
                 modules.push_back(get_initmod_profiler_inlined(c, bits_64, debug));

--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -386,12 +386,11 @@ void lower_impl(const vector<Function> &output_funcs,
     s = lower_unsafe_promises(s, t);
     log("Lowering after lowering unsafe promises:", s);
 
-#if LLVM_VERSION >= 12
+#if LLVM_VERSION >= 120
     if (t.has_feature(Target::AVX512_SapphireRapids)) {
         debug(1) << "Extracting tile operations...\n";
         s = extract_tile_operations(s);
-        debug(2) << "Lowering after extracting tile operations:\n"
-                 << s << "\n\n";
+        log("Lowering after extracting tile operations:", s);
     }
 #endif
 

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -115,7 +115,7 @@ set(RUNTIME_LL
     x86_sse41
     )
 
-if (LLVM_PACKAGE_VERSION VERSION_GREATER_EQUAL 12.0)
+if (Halide_LLVM_VERSION VERSION_GREATER_EQUAL 12.0)
   # AMX instructions require LLVM 12 or newer
   list(APPEND RUNTIME_LL x86_amx)
 endif ()

--- a/src/runtime/x86_amx.ll
+++ b/src/runtime/x86_amx.ll
@@ -16,6 +16,36 @@ define weak_odr <256 x i32> @tdpbssd(i16 %rows, i16 %colbytes, i16 %acc, <256 x 
 }
 declare x86_amx @llvm.x86.tdpbssd.internal(i16, i16, i16, x86_amx, x86_amx, x86_amx)
 
+define weak_odr <256 x i32> @tdpbsud(i16 %rows, i16 %colbytes, i16 %acc, <256 x i32> %out, <1024 x i8> %lhs, <1024 x i8> %rhs) nounwind alwaysinline readnone {
+  %1 = bitcast <1024 x i8> %lhs to x86_amx
+  %2 = bitcast <1024 x i8> %rhs to x86_amx
+  %3 = bitcast <256 x i32> %out to x86_amx
+  %4 = tail call x86_amx @llvm.x86.tdpbsud.internal(i16 %rows, i16 %colbytes, i16 %acc, x86_amx %3, x86_amx %1, x86_amx %2) nounwind readnone
+  %5 = bitcast x86_amx %4 to <256 x i32>
+  ret <256 x i32> %5
+}
+declare x86_amx @llvm.x86.tdpbsud.internal(i16, i16, i16, x86_amx, x86_amx, x86_amx)
+
+define weak_odr <256 x i32> @tdpbusd(i16 %rows, i16 %colbytes, i16 %acc, <256 x i32> %out, <1024 x i8> %lhs, <1024 x i8> %rhs) nounwind alwaysinline readnone {
+  %1 = bitcast <1024 x i8> %lhs to x86_amx
+  %2 = bitcast <1024 x i8> %rhs to x86_amx
+  %3 = bitcast <256 x i32> %out to x86_amx
+  %4 = tail call x86_amx @llvm.x86.tdpbusd.internal(i16 %rows, i16 %colbytes, i16 %acc, x86_amx %3, x86_amx %1, x86_amx %2) nounwind readnone
+  %5 = bitcast x86_amx %4 to <256 x i32>
+  ret <256 x i32> %5
+}
+declare x86_amx @llvm.x86.tdpbusd.internal(i16, i16, i16, x86_amx, x86_amx, x86_amx)
+
+define weak_odr <256 x i32> @tdpbuud(i16 %rows, i16 %colbytes, i16 %acc, <256 x i32> %out, <1024 x i8> %lhs, <1024 x i8> %rhs) nounwind alwaysinline readnone {
+  %1 = bitcast <1024 x i8> %lhs to x86_amx
+  %2 = bitcast <1024 x i8> %rhs to x86_amx
+  %3 = bitcast <256 x i32> %out to x86_amx
+  %4 = tail call x86_amx @llvm.x86.tdpbuud.internal(i16 %rows, i16 %colbytes, i16 %acc, x86_amx %3, x86_amx %1, x86_amx %2) nounwind readnone
+  %5 = bitcast x86_amx %4 to <256 x i32>
+  ret <256 x i32> %5
+}
+declare x86_amx @llvm.x86.tdpbuud.internal(i16, i16, i16, x86_amx, x86_amx, x86_amx)
+
 define weak_odr <2 x i1> @tilestored64(i16 %rows, i16 %cols, i8* %ptr, i64 %off, i64 %stride, <256 x i32> %val) nounwind alwaysinline writeonly {
   %1 = getelementptr i8, i8* %ptr, i64 %off
   %2 = bitcast <256 x i32> %val to x86_amx

--- a/test/performance/tiled_matmul.cpp
+++ b/test/performance/tiled_matmul.cpp
@@ -41,13 +41,13 @@ void fill_buffer_b(Buffer<IntT> &buf, int col, int acc) {
     }
 }
 
-template<bool LhsSigned, bool RhsSigned>
+template<typename LhsInt8, typename RhsInt8>
 bool matmul() {
-    auto lhs = std::conditional_t<LhsSigned, make_int_t, make_uint_t>{};
-    auto rhs = std::conditional_t<RhsSigned, make_int_t, make_uint_t>{};
+    constexpr bool lhs_signed = std::is_signed<LhsInt8>::value;
+    constexpr bool rhs_signed = std::is_signed<RhsInt8>::value;
 
-    using LhsInt8 = std::conditional_t<LhsSigned, int8_t, uint8_t>;
-    using RhsInt8 = std::conditional_t<RhsSigned, int8_t, uint8_t>;
+    auto lhs = std::conditional_t<lhs_signed, make_int_t, make_uint_t>{};
+    auto rhs = std::conditional_t<rhs_signed, make_int_t, make_uint_t>{};
 
     Target target = get_jit_target_from_environment();
     if (!target.has_feature(Target::AVX512_SapphireRapids)) {
@@ -146,10 +146,10 @@ bool matmul() {
     return true;
 }
 
-auto matmul_ss = &matmul<true, false>;
-auto matmul_us = &matmul<false, true>;
-auto matmul_su = &matmul<true, false>;
-auto matmul_uu = &matmul<false, false>;
+auto matmul_ss = &matmul<int8_t, int8_t>;
+auto matmul_us = &matmul<uint8_t, int8_t>;
+auto matmul_su = &matmul<int8_t, uint8_t>;
+auto matmul_uu = &matmul<uint8_t, uint8_t>;
 
 int main(int argc, char **argv) {
     matmul_ss();


### PR DESCRIPTION
Adds support for `tdpb{su, us, uu}d`, which can only be selected on LLVM >= 13.